### PR TITLE
Switch imports to DVCS. Fix peer vs peerstore ambiguity.

### DIFF
--- a/hosts/main.go
+++ b/hosts/main.go
@@ -8,18 +8,18 @@ import (
 	"log"
 	"time"
 
-	host "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/host"
-	bhost "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/host/basic"
-	metrics "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/metrics"
-	net "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/net"
-	conn "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/net/conn"
-	swarm "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/net/swarm"
-	testutil "gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/testutil"
-	pstore "gx/ipfs/QmZ62t46e9p7vMYqCmptwQC1RhRv5cpQ5cwoqYspedaXyq/go-libp2p-peerstore"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
+	host "github.com/ipfs/go-libp2p/p2p/host"
+	bhost "github.com/ipfs/go-libp2p/p2p/host/basic"
+	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
+	net "github.com/ipfs/go-libp2p/p2p/net"
+	conn "github.com/ipfs/go-libp2p/p2p/net/conn"
+	swarm "github.com/ipfs/go-libp2p/p2p/net/swarm"
+	testutil "github.com/ipfs/go-libp2p/testutil"
 
 	ipfsaddr "github.com/ipfs/go-ipfs/thirdparty/ipfsaddr"
-	ma "gx/ipfs/QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd/go-multiaddr"
-	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
+	ma "github.com/jbenet/go-multiaddr"
+	context "golang.org/x/net/context"
 )
 
 var _ = io.Copy

--- a/main.go
+++ b/main.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"time"
 
-	"gx/ipfs/QmQGwpJy9P4yXZySmqkZEXCmbBpJUb8xntCv8Ca4taZwDC/go-libp2p-peer"
-	"gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/metrics"
-	"gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/net"
-	"gx/ipfs/QmXJBB9U6e6ennAJPzk8E2rSaVGuHVR2jCxE9H9gPDtRrq/go-libp2p/p2p/net/swarm"
-	ma "gx/ipfs/QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd/go-multiaddr"
-	"gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
+	"golang.org/x/net/context"
+
+	"github.com/ipfs/go-libp2p-peer"
+	"github.com/ipfs/go-libp2p-peerstore"
+	"github.com/ipfs/go-libp2p/p2p/metrics"
+	"github.com/ipfs/go-libp2p/p2p/net"
+	"github.com/ipfs/go-libp2p/p2p/net/swarm"
+	ma "github.com/jbenet/go-multiaddr"
 )
 
 func Fatal(i interface{}) {
@@ -65,7 +67,7 @@ func main() {
 	}
 
 	// new empty peerstore
-	pstore := peer.NewPeerstore()
+	pstore := peerstore.NewPeerstore()
 	ctx := context.Background()
 
 	// construct ourselves a swarmy thingy


### PR DESCRIPTION
Once https://github.com/ipfs/go-libp2p/issues/66 is fixed, this project should build out of the box.

~~Haven't confirmed functionality yet, though.~~ Seems to function on LAN, fails across NAT. I suppose that's working as intended. :P
